### PR TITLE
Add scheduling info

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ Simple scripts for scraping PopMart products, listening for priority links via D
 - Buyer bot: `python buyer_bot.py`
 
 Each script loads the `.env` file for configuration.
+## Scheduling
+
+The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:
+
+```cron
+# Run scraper every hour
+0 * * * * cd /LaBotBot && /LaBotBot/.venv/bin/python scraper.py >> /var/log/scraper.log 2>&1
+
+# Run buyer bot every 10 minutes
+*/10 * * * * cd /LaBotBot && /LaBotBot/.venv/bin/python buyer_bot.py >> /var/log/buyer.log 2>&1
+```
+


### PR DESCRIPTION
## Summary
- document how to schedule the scraper and buyer bot with cron

## Testing
- `python -m py_compile buyer_bot.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686ae9180f008326a46dfca1a3a916cf