### PR TITLE
Add simple dashboard for bot status

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Simple scripts for scraping PopMart products, listening for priority links via D
 - Buyer bot: `python buyer_bot.py`
 
 Each script loads the `.env` file for configuration.
+## Dashboard
+
+Run `python dashboard.py` to start a simple status page on `http://localhost:8000`.
+The page refreshes automatically every 10 seconds and lists the priority links
+that the buyer bot will attempt to purchase. JSON APIs are also available at
+`/api/priority` and `/api/products`.
 ## Scheduling
 
 The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,47 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from redis_db import get_priority_links, get_all_products
+import json
+import time
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    def _send_json(self, data):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(data, indent=2).encode())
+
+    def do_GET(self):
+        if self.path == '/api/priority':
+            links = get_priority_links()
+            self._send_json(links)
+            return
+        elif self.path == '/api/products':
+            products = get_all_products()
+            self._send_json(products)
+            return
+
+        priority = get_priority_links()
+        html = ["<html><head>",
+                "<meta http-equiv='refresh' content='10'>",
+                "<title>LaBotBot Status</title>",
+                "</head><body>",
+                "<h1>LaBotBot Status</h1>",
+                f"<p>Updated: {time.ctime()}</p>",
+                "<h2>Priority Links</h2>",
+                "<ul>"]
+        for link in priority:
+            html.append(f"<li>{link}</li>")
+        html.extend(["</ul>", "</body></html>"])
+        html_content = "".join(html)
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(html_content.encode())
+
+def run(port=8000):
+    server = HTTPServer(('0.0.0.0', port), DashboardHandler)
+    print(f"Serving dashboard on http://0.0.0.0:{port} ...")
+    server.serve_forever()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- create `dashboard.py` server to show priority links
- document running the dashboard in the README

## Testing
- `python -m py_compile dashboard.py buyer_bot.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686aedfbc140832687418b281219279c