### PR TITLE
Escape priority links in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from redis_db import get_priority_links, get_all_products
 import json
 import time
+import html
 
 class DashboardHandler(BaseHTTPRequestHandler):
     def _send_json(self, data):
@@ -21,7 +22,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             return
 
         priority = get_priority_links()
-        html = ["<html><head>",
+        html_parts = ["<html><head>",
                 "<meta http-equiv='refresh' content='10'>",
                 "<title>LaBotBot Status</title>",
                 "</head><body>",
@@ -30,9 +31,9 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 "<h2>Priority Links</h2>",
                 "<ul>"]
         for link in priority:
-            html.append(f"<li>{link}</li>")
-        html.extend(["</ul>", "</body></html>"])
-        html_content = "".join(html)
+            html_parts.append(f"<li>{html.escape(link)}</li>")
+        html_parts.extend(["</ul>", "</body></html>"])
+        html_content = "".join(html_parts)
         self.send_response(200)
         self.send_header('Content-Type', 'text/html')
         self.end_headers()


### PR DESCRIPTION
## Summary
- escape priority links before rendering HTML
- import Python `html` module to use `escape`

## Testing
- `python -m py_compile buyer_bot.py dashboard.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686af52bf33c8326987cf70d16eb08fd