### PR TITLE
Handle Redis errors in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,26 +1,49 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from redis_db import get_priority_links, get_all_products
+from redis.exceptions import ConnectionError as RedisConnectionError
 import json
 import time
 
 class DashboardHandler(BaseHTTPRequestHandler):
-    def _send_json(self, data):
-        self.send_response(200)
+    def _send_json(self, data, status=200):
+        self.send_response(status)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
         self.wfile.write(json.dumps(data, indent=2).encode())
 
+    def _send_html(self, html, status=200):
+        self.send_response(status)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(html.encode())
+
     def do_GET(self):
         if self.path == '/api/priority':
-            links = get_priority_links()
+            try:
+                links = get_priority_links()
+            except RedisConnectionError:
+                self._send_json({'error': 'Cannot connect to Redis'}, status=503)
+                return
             self._send_json(links)
             return
         elif self.path == '/api/products':
-            products = get_all_products()
+            try:
+                products = get_all_products()
+            except RedisConnectionError:
+                self._send_json({'error': 'Cannot connect to Redis'}, status=503)
+                return
             self._send_json(products)
             return
 
-        priority = get_priority_links()
+        try:
+            priority = get_priority_links()
+        except RedisConnectionError:
+            html = (
+                "<html><body><h1>Service Unavailable</h1>"
+                "<p>Cannot connect to Redis</p></body></html>"
+            )
+            self._send_html(html, status=503)
+            return
         html = ["<html><head>",
                 "<meta http-equiv='refresh' content='10'>",
                 "<title>LaBotBot Status</title>",
@@ -33,10 +56,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             html.append(f"<li>{link}</li>")
         html.extend(["</ul>", "</body></html>"])
         html_content = "".join(html)
-        self.send_response(200)
-        self.send_header('Content-Type', 'text/html')
-        self.end_headers()
-        self.wfile.write(html_content.encode())
+        self._send_html(html_content)
 
 def run(port=8000):
     server = HTTPServer(('0.0.0.0', port), DashboardHandler)


### PR DESCRIPTION
## Summary
- ensure dashboard gracefully handles Redis connection issues
- return JSON or HTML with HTTP 503 when Redis cannot be reached

## Testing
- `python -m py_compile dashboard.py redis_db.py buyer_bot.py scraper.py utils.py discord_listener.py sync_to_mongo.py`

------
https://chatgpt.com/codex/tasks/task_e_686af52db900832696fabd31cc2a24e0