### PR TITLE
Add configurable host and port for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ Simple scripts for scraping PopMart products, listening for priority links via D
 Each script loads the `.env` file for configuration.
 ## Dashboard
 
-Run `python dashboard.py` to start a simple status page on `http://localhost:8000`.
-The page refreshes automatically every 10 seconds and lists the priority links
-that the buyer bot will attempt to purchase. JSON APIs are also available at
-`/api/priority` and `/api/products`.
+Run `python dashboard.py` to start a simple status page. By default the
+dashboard binds to `http://127.0.0.1:8000`. Use the `--host` and `--port`
+options or set the `DASHBOARD_HOST` and `DASHBOARD_PORT` environment variables
+to change the interface or port. The page refreshes automatically every 10
+seconds and lists the priority links that the buyer bot will attempt to
+purchase. JSON APIs are also available at `/api/priority` and `/api/products`.
 ## Scheduling
 
 The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,8 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from redis_db import get_priority_links, get_all_products
 import json
 import time
+import os
+import argparse
 
 class DashboardHandler(BaseHTTPRequestHandler):
     def _send_json(self, data):
@@ -38,10 +40,19 @@ class DashboardHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(html_content.encode())
 
-def run(port=8000):
-    server = HTTPServer(('0.0.0.0', port), DashboardHandler)
-    print(f"Serving dashboard on http://0.0.0.0:{port} ...")
+def run(host=None, port=None):
+    if host is None:
+        host = os.getenv("DASHBOARD_HOST", "127.0.0.1")
+    if port is None:
+        port = int(os.getenv("DASHBOARD_PORT", "8000"))
+
+    server = HTTPServer((host, port), DashboardHandler)
+    print(f"Serving dashboard on http://{host}:{port} ...")
     server.serve_forever()
 
 if __name__ == '__main__':
-    run()
+    parser = argparse.ArgumentParser(description="Start the LaBotBot dashboard")
+    parser.add_argument("--host", help="Interface to bind to", default=os.getenv("DASHBOARD_HOST"))
+    parser.add_argument("--port", type=int, help="Port to listen on", default=os.getenv("DASHBOARD_PORT"))
+    args = parser.parse_args()
+    run(args.host, args.port)


### PR DESCRIPTION
## Summary
- allow passing `--host` and `--port` in `dashboard.py`
- fallback to `DASHBOARD_HOST` and `DASHBOARD_PORT` env vars
- default to `127.0.0.1:8000`
- document these options in the README

## Testing
- `python -m py_compile buyer_bot.py dashboard.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py`
- *(failure: running the dashboard requires missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686af52f9e988326851e1c4d1c1e98ac