### PR TITLE
Improve dashboard and add basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Simple scripts for scraping PopMart products, listening for priority links via D
    DISCORD_NOTIFY_CHANNEL_ID=1234567890
    MAX_DAILY_BUDGET=100.0
    MONGODB_URI=mongodb+srv://<db_username>:<db_password>@cluster0.ecntfwt.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+   DASHBOARD_USER=admin
+   DASHBOARD_PASS=secret
    ```
    Replace the values with your own credentials. When using MongoDB Atlas, paste your cluster's connection string into `MONGODB_URI`.
 4. Ensure Redis and MongoDB are running and accessible. If using Atlas, whitelist your VM's IP address.
@@ -46,6 +48,10 @@ Run `python dashboard.py` to start a simple status page on `http://localhost:800
 The page refreshes automatically every 10 seconds and lists the priority links
 that the buyer bot will attempt to purchase. JSON APIs are also available at
 `/api/priority` and `/api/products`.
+If you set `DASHBOARD_USER` and `DASHBOARD_PASS` in your `.env` file, the page
+will require HTTP Basic authentication. Host and port can be overridden with the
+`DASHBOARD_HOST` and `DASHBOARD_PORT` environment variables. For secure remote
+access, consider tunneling the port over SSH instead of exposing it directly.
 ## Scheduling
 
 The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,15 +3,40 @@ from redis_db import get_priority_links, get_all_products
 import json
 import time
 import html
+import base64
+import os
+
+DASHBOARD_USER = os.getenv("DASHBOARD_USER")
+DASHBOARD_PASS = os.getenv("DASHBOARD_PASS")
+
 
 class DashboardHandler(BaseHTTPRequestHandler):
     def _send_json(self, data):
         self.send_response(200)
-        self.send_header('Content-Type', 'application/json')
+        self.send_header("Content-Type", "application/json")
         self.end_headers()
         self.wfile.write(json.dumps(data, indent=2).encode())
 
+    def _check_auth(self):
+        """Return True if no auth required or valid Basic Auth header present."""
+        if not DASHBOARD_USER:
+            return True
+        auth_header = self.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Basic "):
+            return False
+        try:
+            decoded = base64.b64decode(auth_header.split(" ")[1]).decode()
+            user, _, password = decoded.partition(":")
+        except Exception:
+            return False
+        return user == DASHBOARD_USER and password == DASHBOARD_PASS
+
     def do_GET(self):
+        if not self._check_auth():
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", "Basic realm=\"LaBotBot\"")
+            self.end_headers()
+            return
         if self.path == '/api/priority':
             links = get_priority_links()
             self._send_json(links)
@@ -22,27 +47,45 @@ class DashboardHandler(BaseHTTPRequestHandler):
             return
 
         priority = get_priority_links()
-        html_parts = ["<html><head>",
-                "<meta http-equiv='refresh' content='10'>",
-                "<title>LaBotBot Status</title>",
-                "</head><body>",
-                "<h1>LaBotBot Status</h1>",
-                f"<p>Updated: {time.ctime()}</p>",
-                "<h2>Priority Links</h2>",
-                "<ul>"]
+        products = get_all_products()
+
+        html_parts = [
+            "<html><head>",
+            "<meta http-equiv='refresh' content='10'>",
+            "<title>LaBotBot Status</title>",
+            "</head><body>",
+            "<h1>LaBotBot Status</h1>",
+            f"<p>Updated: {time.ctime()}</p>",
+            "<h2>Priority Links</h2>",
+            "<ul>"
+        ]
         for link in priority:
             html_parts.append(f"<li>{html.escape(link)}</li>")
-        html_parts.extend(["</ul>", "</body></html>"])
+        html_parts.extend([
+            "</ul>",
+            "<h2>Products</h2>",
+            "<table border='1'><tr><th>Name</th><th>Price</th><th>In Stock</th></tr>"
+        ])
+        for p in products:
+            name = html.escape(p.get("name", ""))
+            price = p.get("price", "")
+            stock = "Yes" if p.get("in_stock") == '1' else "No"
+            html_parts.append(
+                f"<tr><td>{name}</td><td>${price}</td><td>{stock}</td></tr>"
+            )
+        html_parts.extend(["</table>", "</body></html>"])
         html_content = "".join(html_parts)
         self.send_response(200)
         self.send_header('Content-Type', 'text/html')
         self.end_headers()
         self.wfile.write(html_content.encode())
 
-def run(port=8000):
-    server = HTTPServer(('0.0.0.0', port), DashboardHandler)
-    print(f"Serving dashboard on http://0.0.0.0:{port} ...")
+def run(host="0.0.0.0", port=8000):
+    server = HTTPServer((host, port), DashboardHandler)
+    print(f"Serving dashboard on http://{host}:{port} ...")
     server.serve_forever()
 
 if __name__ == '__main__':
-    run()
+    host = os.getenv("DASHBOARD_HOST", "0.0.0.0")
+    port = int(os.getenv("DASHBOARD_PORT", "8000"))
+    run(host=host, port=port)


### PR DESCRIPTION
## Summary
- secure dashboard with optional HTTP Basic Auth
- show product table on dashboard
- allow host/port overrides with env vars
- document new DASHBOARD environment variables and remote access guidance

## Testing
- `python -m py_compile buyer_bot.py dashboard.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py`
- `flake8 dashboard.py | head` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_686ae40b28b88326960c2515da47ec08