### PR TITLE
Add orchestrator for automated loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,32 +29,79 @@ Simple scripts for scraping PopMart products, listening for priority links via D
    DISCORD_NOTIFY_CHANNEL_ID=1234567890
    MAX_DAILY_BUDGET=100.0
    MONGODB_URI=mongodb+srv://<db_username>:<db_password>@cluster0.ecntfwt.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+   DASHBOARD_USER=admin
+   DASHBOARD_PASS=secret
    ```
    Replace the values with your own credentials. When using MongoDB Atlas, paste your cluster's connection string into `MONGODB_URI`.
 4. Ensure Redis and MongoDB are running and accessible. If using Atlas, whitelist your VM's IP address.
 
 ## Running
 
-- Scraper: `python scraper.py`
-- Discord listener: `python discord_listener.py`
-- Buyer bot: `python buyer_bot.py`
+The usual workflow is:
 
-Each script loads the `.env` file for configuration.
+1. Run the scraper to collect product data:
+   ```bash
+   python scraper.py
+   ```
+2. Optionally run the Discord listener if you want to add links via Discord:
+   ```bash
+   python discord_listener.py
+   ```
+3. Run the buyer bot to attempt purchases:
+   ```bash
+   python buyer_bot.py
+   ```
+
+Each script loads the `.env` file for configuration. If `DISCORD_BOT_TOKEN` and
+`DISCORD_NOTIFY_CHANNEL_ID` are not set, the buyer bot prints notifications to
+stdout instead of sending them to Discord.
+
+To run everything automatically, use the `run_all.py` helper:
+
+```bash
+python run_all.py
+```
+
+This script launches the dashboard in a background process, runs the scraper,
+then runs the buyer bot. It repeats this cycle every hour by default. Set the
+`RUN_INTERVAL` environment variable (in seconds) to change the interval.
 ## Dashboard
 
 Run `python dashboard.py` to start a simple status page on `http://localhost:8000`.
 The page refreshes automatically every 10 seconds and lists the priority links
 that the buyer bot will attempt to purchase. JSON APIs are also available at
 `/api/priority` and `/api/products`.
+If you set `DASHBOARD_USER` and `DASHBOARD_PASS` in your `.env` file, the page
+will require HTTP Basic authentication. The dashboard binds to `127.0.0.1` by
+default. To expose it remotely, set `DASHBOARD_HOST` and `DASHBOARD_PORT` in
+your environment, e.g. `DASHBOARD_HOST=64.225.91.160`. For secure remote
+access, consider tunneling the port over SSH instead of exposing it directly.
 ## Scheduling
 
 The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:
 
 ```cron
-# Run scraper every hour
-0 * * * * cd /LaBotBot && /LaBotBot/.venv/bin/python scraper.py >> /var/log/scraper.log 2>&1
+# Automatically start everything at boot
+@reboot cd /LaBotBot && /LaBotBot/.venv/bin/python run_all.py >> /var/log/labotbot.log 2>&1
 
-# Run buyer bot every 10 minutes
+# If you prefer separate jobs, schedule them like this:
+0 * * * * cd /LaBotBot && /LaBotBot/.venv/bin/python scraper.py >> /var/log/scraper.log 2>&1
 */10 * * * * cd /LaBotBot && /LaBotBot/.venv/bin/python buyer_bot.py >> /var/log/buyer.log 2>&1
+```
+
+## Troubleshooting
+
+If the `playwright` command is missing after a reboot, reactivate the virtual
+environment:
+
+```bash
+source .venv/bin/activate
+```
+
+Then reinstall dependencies and browsers if needed:
+
+```bash
+pip install -r requirements.txt
+playwright install
 ```
 

--- a/buyer_bot.py
+++ b/buyer_bot.py
@@ -4,7 +4,6 @@ from dotenv import load_dotenv
 from utils import try_to_buy, get_price
 import discord
 import asyncio
-import time
 import os
 
 load_dotenv()

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,15 +3,40 @@ from redis_db import get_priority_links, get_all_products
 import json
 import time
 import html
+import base64
+import os
+
+DASHBOARD_USER = os.getenv("DASHBOARD_USER")
+DASHBOARD_PASS = os.getenv("DASHBOARD_PASS")
+
 
 class DashboardHandler(BaseHTTPRequestHandler):
     def _send_json(self, data):
         self.send_response(200)
-        self.send_header('Content-Type', 'application/json')
+        self.send_header("Content-Type", "application/json")
         self.end_headers()
         self.wfile.write(json.dumps(data, indent=2).encode())
 
+    def _check_auth(self):
+        """Return True if auth disabled or Authorization header is valid."""
+        if not DASHBOARD_USER:
+            return True
+        auth_header = self.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Basic "):
+            return False
+        try:
+            decoded = base64.b64decode(auth_header.split(" ")[1]).decode()
+            user, _, password = decoded.partition(":")
+        except Exception:
+            return False
+        return user == DASHBOARD_USER and password == DASHBOARD_PASS
+
     def do_GET(self):
+        if not self._check_auth():
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", "Basic realm=\"LaBotBot\"")
+            self.end_headers()
+            return
         if self.path == '/api/priority':
             links = get_priority_links()
             self._send_json(links)
@@ -22,27 +47,50 @@ class DashboardHandler(BaseHTTPRequestHandler):
             return
 
         priority = get_priority_links()
-        html_parts = ["<html><head>",
-                "<meta http-equiv='refresh' content='10'>",
-                "<title>LaBotBot Status</title>",
-                "</head><body>",
-                "<h1>LaBotBot Status</h1>",
-                f"<p>Updated: {time.ctime()}</p>",
-                "<h2>Priority Links</h2>",
-                "<ul>"]
+        products = get_all_products()
+
+        html_parts = [
+            "<html><head>",
+            "<meta http-equiv='refresh' content='10'>",
+            "<title>LaBotBot Status</title>",
+            "</head><body>",
+            "<h1>LaBotBot Status</h1>",
+            f"<p>Updated: {time.ctime()}</p>",
+            "<h2>Priority Links</h2>",
+            "<ul>"
+        ]
         for link in priority:
             html_parts.append(f"<li>{html.escape(link)}</li>")
-        html_parts.extend(["</ul>", "</body></html>"])
+        html_parts.extend([
+            "</ul>",
+            "<h2>Products</h2>",
+            (
+                "<table border='1'><tr>"
+                "<th>Name</th><th>Price</th><th>In Stock</th></tr>"
+            )
+        ])
+        for p in products:
+            name = html.escape(p.get("name", ""))
+            price = p.get("price", "")
+            stock = "Yes" if p.get("in_stock") == '1' else "No"
+            html_parts.append(
+                f"<tr><td>{name}</td><td>${price}</td><td>{stock}</td></tr>"
+            )
+        html_parts.extend(["</table>", "</body></html>"])
         html_content = "".join(html_parts)
         self.send_response(200)
         self.send_header('Content-Type', 'text/html')
         self.end_headers()
         self.wfile.write(html_content.encode())
 
-def run(port=8000):
-    server = HTTPServer(('0.0.0.0', port), DashboardHandler)
-    print(f"Serving dashboard on http://0.0.0.0:{port} ...")
+
+def run(host="127.0.0.1", port=8000):
+    server = HTTPServer((host, port), DashboardHandler)
+    print(f"Serving dashboard on http://{host}:{port} ...")
     server.serve_forever()
 
+
 if __name__ == '__main__':
-    run()
+    host = os.getenv("DASHBOARD_HOST", "127.0.0.1")
+    port = int(os.getenv("DASHBOARD_PORT", "8000"))
+    run(host=host, port=port)

--- a/run_all.py
+++ b/run_all.py
@@ -1,0 +1,27 @@
+import os
+import time
+from multiprocessing import Process
+
+from dashboard import run as run_dashboard
+from scraper import scrape
+from buyer_bot import run as run_buyer
+
+
+def start_dashboard():
+    host = os.getenv("DASHBOARD_HOST", "127.0.0.1")
+    port = int(os.getenv("DASHBOARD_PORT", "8000"))
+    run_dashboard(host=host, port=port)
+
+
+def main():
+    interval = int(os.getenv("RUN_INTERVAL", "3600"))
+    dash_proc = Process(target=start_dashboard, daemon=True)
+    dash_proc.start()
+    while True:
+        scrape()
+        run_buyer()
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `run_all.py` to launch the dashboard and cycle scraper & buyer bot
- document `run_all.py` usage and cron setup in the README

## Testing
- `python -m py_compile buyer_bot.py dashboard.py discord_listener.py redis_db.py scraper.py sync_to_mongo.py utils.py run_all.py`
- `flake8 dashboard.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686ae40b28b88326960c2515da47ec08