### PR TITLE
Improve Mongo sync logging

### DIFF
--- a/sync_to_mongo.py
+++ b/sync_to_mongo.py
@@ -17,41 +17,47 @@ product_collection.create_index("priority_score")
 
 def sync_from_redis_to_mongo():
     ids = r.zrange("product_ids", 0, -1)
+    print(f"Syncing {len(ids)} products from Redis to MongoDB ...")
     for pid in ids:
         product = r.hgetall(f"product:{pid}")
-        if product:
-            product_doc = {
-                "_id": pid,
-                "name": product.get("name"),
-                "url": product.get("url"),
-                "price": float(product.get("price", 0)),
-                "currency": "USD",
-                "description": product.get("description", ""),
-                "image_url": product.get("image", ""),
-                "availability": {
-                    "in_stock": bool(int(product.get("in_stock", 0))),
-                    "last_checked": datetime.utcnow().isoformat()
-                },
-                "priority_score": int(product.get("priority_score", 0)),
-                "is_priority": bool(int(product.get("is_priority", 0))),
-                "source": product.get("source", "scraped"),
-                "history": [
-                    {
-                        "timestamp": datetime.utcnow().isoformat(),
-                        "price": float(product.get("price", 0)),
-                        "in_stock": bool(int(product.get("in_stock", 0)))
-                    }
-                ],
-                "tags": product.get("tags", "").split(",") if product.get("tags") else []
-            }
-            product_collection.update_one(
-                {"_id": pid},
-                {"$set": product_doc, "$push": {"history": product_doc["history"][0]}},
-                upsert=True
-            )
+        if not product:
+            continue
+
+        history_entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "price": float(product.get("price", 0)),
+            "in_stock": bool(int(product.get("in_stock", 0)))
+        }
+
+        product_doc = {
+            "_id": pid,
+            "name": product.get("name"),
+            "url": product.get("url"),
+            "price": float(product.get("price", 0)),
+            "currency": "USD",
+            "description": product.get("description", ""),
+            "image_url": product.get("image", ""),
+            "availability": {
+                "in_stock": bool(int(product.get("in_stock", 0))),
+                "last_checked": datetime.utcnow().isoformat()
+            },
+            "priority_score": int(product.get("priority_score", 0)),
+            "is_priority": bool(int(product.get("is_priority", 0))),
+            "source": product.get("source", "scraped"),
+            "tags": product.get("tags", "").split(",") if product.get("tags") else []
+        }
+
+        product_collection.update_one(
+            {"_id": pid},
+            {"$set": product_doc, "$push": {"history": history_entry}},
+            upsert=True
+        )
+        print(f"Synced product {pid}")
 
 def sync_from_mongo_to_redis(limit=50):
-    for doc in product_collection.find({"availability.in_stock": True, "price": {"$lte": 30}}).limit(limit):
+    cursor = product_collection.find({"availability.in_stock": True, "price": {"$lte": 30}}).limit(limit)
+    count = 0
+    for doc in cursor:
         pid = doc["_id"]
         r.hset(f"product:{pid}", mapping={
             "name": doc.get("name"),
@@ -67,3 +73,5 @@ def sync_from_mongo_to_redis(limit=50):
         })
         r.zadd("product_ids", {pid: 0})
         r.expire(f"product:{pid}", 43200)
+        count += 1
+    print(f"Synced {count} products from MongoDB to Redis")


### PR DESCRIPTION
## Summary
- refactor history push logic and remove duplicate history set
- add console output for sync progress

## Testing
- `python -m py_compile sync_to_mongo.py`
- `python -m py_compile scraper.py buyer_bot.py redis_db.py dashboard.py utils.py run_all.py discord_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_686b3809d0d48326976f2e840ac2be4a