### PR TITLE
Refactor buyer bot login and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Simple scripts for scraping PopMart products, listening for priority links via D
    DISCORD_BOT_TOKEN=your_discord_token
    DISCORD_NOTIFY_CHANNEL_ID=1234567890
    MAX_DAILY_BUDGET=100.0
+   MAX_ITEMS=6
    MONGODB_USERNAME=db_username
    MONGODB_PASSWORD=db_password
    MONGODB_CLUSTER=cluster0.ecntfwt.mongodb.net
@@ -58,6 +59,7 @@ The usual workflow is:
 Each script loads the `.env` file for configuration. If `DISCORD_BOT_TOKEN` and
 `DISCORD_NOTIFY_CHANNEL_ID` are not set, the buyer bot prints notifications to
 stdout instead of sending them to Discord.
+The buyer bot also logs its actions to `buyer_bot.log` for later review.
 
 To run everything automatically, use the `run_all.py` helper:
 

--- a/buyer_bot.py
+++ b/buyer_bot.py
@@ -1,10 +1,21 @@
 from playwright.sync_api import sync_playwright
 from redis_db import get_priority_links
 from dotenv import load_dotenv
-from utils import try_to_buy, get_price
+from utils import try_to_buy, get_price, login
 import discord
 import asyncio
+import logging
 import os
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[
+        logging.FileHandler("buyer_bot.log"),
+        logging.StreamHandler(),
+    ],
+)
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 USERNAME = os.getenv("POP_USERNAME")
@@ -14,7 +25,7 @@ DISCORD_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DAILY_BUDGET = os.getenv("MAX_DAILY_BUDGET")
 DAILY_BUDGET = float(DAILY_BUDGET) if DAILY_BUDGET else 0.0
 
-MAX_ITEMS = 6
+MAX_ITEMS = int(os.getenv("MAX_ITEMS", "6"))
 
 def notify_discord(message):
     async def send():
@@ -37,6 +48,19 @@ def run():
         context.add_init_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined});")
         page = context.new_page()
 
+        if USERNAME and PASSWORD:
+            logger.info("Logging in as %s", USERNAME)
+            try:
+                login(page, USERNAME, PASSWORD)
+            except Exception as e:
+                logger.error("Login failed: %s", e)
+                browser.close()
+                return
+        else:
+            logger.error("POP_USERNAME or POP_PASSWORD not set")
+            browser.close()
+            return
+
         links = get_priority_links()
         count = 0
         spent = 0.0
@@ -50,14 +74,18 @@ def run():
                 print(f"Skipping {link} — daily budget exceeded")
                 continue
 
-            price_paid = try_to_buy(page, link)
-            spent += price_paid
-            message = f"✅ Purchased: {link} for ${price_paid}"
-            if DISCORD_TOKEN and CHANNEL_ID:
-                notify_discord(message)
+            price_paid, success = try_to_buy(page, link)
+            if success:
+                spent += price_paid
+                message = f"✅ Purchased: {link} for ${price_paid}"
+                logger.info(message)
+                if DISCORD_TOKEN and CHANNEL_ID:
+                    notify_discord(message)
+                else:
+                    print(message)
+                count += 1
             else:
-                print(message)
-            count += 1
+                logger.warning("Failed purchase attempt for %s", link)
 
         browser.close()
 

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,12 @@
-def try_to_buy(page, link):
-    from dotenv import load_dotenv
-    import os
-    import time
+import time
+import logging
 
-    load_dotenv()
-    USERNAME = os.getenv("POP_USERNAME")
-    PASSWORD = os.getenv("POP_PASSWORD")
+
+logger = logging.getLogger(__name__)
+
+
+def login(page, username: str, password: str):
+    """Log in to Popmart using the provided credentials."""
 
     login_url = "https://www.popmart.com/us/user/login?redirect=%2Faccount"
     page.goto(login_url, wait_until="domcontentloaded", timeout=60000)
@@ -17,29 +18,47 @@ def try_to_buy(page, link):
         pass
 
     page.wait_for_selector("input#email", timeout=60000)
-    page.fill("input#email", USERNAME)
+    page.fill("input#email", username)
     page.locator("button:has-text('CONTINUE')").click()
 
     page.wait_for_selector("input#password", timeout=60000)
-    page.fill("input#password", PASSWORD)
+    page.fill("input#password", password)
     page.locator("button[type='submit']").click()
-    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_load_state("networkidle")
 
-    page.goto(link, wait_until="networkidle", timeout=120000)
-    print(f"Watching {link} for stock...")
-    page.wait_for_selector(".product__price", timeout=120000)
-    price = page.text_content(".product__price")
-    price_value = float(price.strip().replace("$", "")) if price else 0.0
-    page.wait_for_selector(
-        "button.product__button[name='add']:not([disabled])", timeout=60000
-    )
-    page.click("button.product__button[name='add']")
-    page.goto(
-        "https://www.popmart.com/cart", wait_until="domcontentloaded", timeout=60000
-    )
-    page.click("button[name='checkout']")
-    time.sleep(3)
-    return price_value
+
+def try_to_buy(page, link):
+    """Attempt to buy a product. Expects the user to already be logged in."""
+
+    try:
+        page.goto(link, wait_until="networkidle", timeout=120000)
+        logger.info("Watching %s for stock", link)
+
+        page.wait_for_selector(".product__price", timeout=120000)
+        price = page.text_content(".product__price")
+        price_value = float(price.strip().replace("$", "")) if price else 0.0
+
+        page.wait_for_selector(
+            "button.product__button[name='add']:not([disabled])", timeout=60000
+        )
+        page.click("button.product__button[name='add']")
+        page.goto(
+            "https://www.popmart.com/cart", wait_until="domcontentloaded", timeout=60000
+        )
+        page.click("button[name='checkout']")
+
+        success = False
+        try:
+            page.wait_for_selector("text=Order", timeout=10000)
+            success = True
+        except Exception:
+            logger.warning("Checkout confirmation not detected for %s", link)
+        time.sleep(3)
+        return price_value, success
+
+    except Exception as e:
+        logger.error("Failed to purchase %s: %s", link, e)
+        return 0.0, False
 
 
 def get_price(page, link):
@@ -48,6 +67,6 @@ def get_price(page, link):
         page.wait_for_selector(".product__price", timeout=120000)
         price = page.text_content(".product__price")
     except Exception as e:
-        print(f"Failed to get price from {link}: {e}")
+        logger.error("Failed to get price from %s: %s", link, e)
         return 0.0
     return float(price.strip().replace("$", "")) if price else 0.0


### PR DESCRIPTION
## Summary
- use a single login session when buying items
- make MAX_ITEMS configurable and add logging
- verify checkout success and handle failures gracefully
- log price lookup errors
- document new MAX_ITEMS variable and log file

## Testing
- `python -m py_compile buyer_bot.py utils.py redis_db.py scraper.py dashboard.py discord_listener.py run_all.py sync_to_mongo.py`

------
https://chatgpt.com/codex/tasks/task_e_686c69ecf7548326a9abb9bfb9840bf9