### PR TITLE
Enhance dashboard with Mongo fallback and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,13 @@ then runs the buyer bot. It repeats this cycle every hour by default. Set the
 `RUN_INTERVAL` environment variable (in seconds) to change the interval.
 ## Dashboard
 
-Run `python dashboard.py` to start a simple status page on `http://localhost:8000`.
-The page refreshes automatically every 10 seconds and lists the priority links
-that the buyer bot will attempt to purchase. JSON APIs are also available at
-`/api/priority` and `/api/products`.
+Run `python dashboard.py` to start a status page on `http://localhost:8000`.
+The dashboard now falls back to MongoDB if Redis has no product data and
+displays two tabs: **Products** and **Logs**. The Products tab lists all
+products as well as any priority links. The Logs tab shows the latest output
+from `buyer_bot.log` and indicates whether the buyer bot and scraper processes
+are running.
+JSON APIs remain available at `/api/priority`, `/api/products` and `/api/logs`.
 If you set `DASHBOARD_USER` and `DASHBOARD_PASS` in your `.env` file, the page
 will require HTTP Basic authentication. The dashboard binds to `127.0.0.1` by
 default. To expose it remotely, set `DASHBOARD_HOST` and `DASHBOARD_PORT` in

--- a/tests/test_dashboard_fetch.py
+++ b/tests/test_dashboard_fetch.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock
+import sys
+import types
+
+# Provide a stub redis module so dashboard can be imported without Redis installed
+sys.modules.setdefault('redis', types.SimpleNamespace(Redis=lambda *a, **k: None))
+import importlib.machinery
+pymongo_stub = types.ModuleType('pymongo')
+pymongo_stub.__spec__ = importlib.machinery.ModuleSpec('pymongo', None)
+sys.modules.setdefault('pymongo', pymongo_stub)
+sys.modules.setdefault('dotenv', types.ModuleType('dotenv'))
+sys.modules['dotenv'].load_dotenv = lambda *a, **k: None
+import dashboard
+
+class TestFetchProducts(unittest.TestCase):
+    def test_fallback_called(self):
+        with mock.patch('dashboard.get_all_products', side_effect=[[], ['p']]) as gap, \
+             mock.patch('dashboard.sync_from_mongo_to_redis') as sync:
+            result = dashboard.fetch_products()
+            self.assertEqual(result, ['p'])
+            sync.assert_called_once()
+            self.assertEqual(gap.call_count, 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve dashboard styling and add Products and Logs tabs
- populate Redis from Mongo when Redis is empty
- display buyer bot log and running status of services
- document dashboard features in README
- add tests for dashboard fallback logic

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_686dc44ac1bc8326a56413c442efc5db