### PR TITLE
Add Discord event notifications

### DIFF
--- a/discord_listener.py
+++ b/discord_listener.py
@@ -1,8 +1,9 @@
 
 import discord
 import os
+import asyncio
 from dotenv import load_dotenv
-from labot.redis_db import add_priority_link
+from labot.redis_db import add_priority_link, get_pubsub
 
 load_dotenv()
 TOKEN = os.getenv("DISCORD_BOT_TOKEN")
@@ -13,10 +14,26 @@ intents.messages = True
 intents.message_content = True
 
 client = discord.Client(intents=intents)
+pubsub = get_pubsub()
+
+async def forward_events():
+    await client.wait_until_ready()
+    channel = client.get_channel(CHANNEL_ID)
+    if channel is None:
+        channel = await client.fetch_channel(CHANNEL_ID)
+    while True:
+        msg = pubsub.get_message()
+        if msg and msg.get("type") == "message":
+            content = msg["data"]
+            if isinstance(content, bytes):
+                content = content.decode()
+            await channel.send(content)
+        await asyncio.sleep(1)
 
 @client.event
 async def on_ready():
     print(f"✅ Discord Bot is online as {client.user}")
+    client.loop.create_task(forward_events())
 
 @client.event
 async def on_message(message):

--- a/labot/redis_db.py
+++ b/labot/redis_db.py
@@ -2,6 +2,20 @@ import redis
 
 r = redis.Redis(host='localhost', port=6379, decode_responses=True)
 
+def publish_event(message: str, channel: str = "bot_events") -> None:
+    """Publish a one-off message to the given Redis pubsub channel."""
+    try:
+        r.publish(channel, message)
+    except Exception:
+        # Ignore Redis errors so callers don't fail if Redis is down
+        pass
+
+def get_pubsub(channel: str = "bot_events"):
+    """Return a PubSub instance subscribed to the given channel."""
+    pubsub = r.pubsub()
+    pubsub.subscribe(channel)
+    return pubsub
+
 def save_product(pid, data):
     r.hset(f"product:{pid}", mapping=data)
     r.zadd("product_ids", {pid: 0})


### PR DESCRIPTION
## Summary
- publish bot events to a Redis channel
- post purchase and scraper status events via Redis
- forward Redis events in `discord_listener`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m playwright install`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_686dddacde8c83269b047c3f36e6cf38