### PR TITLE
Fix blank product display in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -21,6 +21,17 @@ def fetch_products():
             products = get_all_products()
         except Exception as e:
             print(f"Mongo fallback failed: {e}")
+    # Filter out items that have both a blank name and blank price
+    def is_blank(value: str) -> bool:
+        return value is None or str(value).strip() == ""
+
+    filtered = []
+    for p in products:
+        if hasattr(p, "get"):
+            if is_blank(p.get("name")) and is_blank(p.get("price")):
+                continue
+        filtered.append(p)
+    products = filtered
     return products
 
 

--- a/tests/test_dashboard_fetch.py
+++ b/tests/test_dashboard_fetch.py
@@ -22,5 +22,20 @@ class TestFetchProducts(unittest.TestCase):
             sync.assert_called_once()
             self.assertEqual(gap.call_count, 2)
 
+    def test_blank_items_filtered(self):
+        products = [
+            {'name': '', 'price': ''},
+            {'name': 'A', 'price': '10'},
+            {'name': '', 'price': '5'},
+            {'name': 'B', 'price': ''},
+        ]
+        with mock.patch('dashboard.get_all_products', return_value=products):
+            result = dashboard.fetch_products()
+        self.assertEqual(result, [
+            {'name': 'A', 'price': '10'},
+            {'name': '', 'price': '5'},
+            {'name': 'B', 'price': ''},
+        ])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- filter out products with no name and no price before rendering dashboard
- add regression test for blank product filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eecb655dc8326b59ef1e328f0100b