### PR TITLE
Add cute dashboard theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ your environment, e.g. `DASHBOARD_HOST=64.225.91.160`. For secure remote
 access, run it behind an HTTPS proxy or tunnel the port over SSH instead of
 exposing it directly. The buyer bot log file is created with permissions `600`
 to keep its contents private.
+
+### Kawaii Dashboard Theme
+
+The `cute_site/` directory contains a lightweight HTML/CSS/JS frontend that
+fetches data from the dashboard APIs and displays it with a pastel color scheme.
+Run `python dashboard.py` and open `cute_site/index.html` in your browser to see
+the more polished, mobile‑friendly interface.
 ## Scheduling
 
 The scripts can be scheduled with cron. While logged in as `labot`, add entries using `crontab -e`:

--- a/cute_site/index.html
+++ b/cute_site/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kawaii Dashboard</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="page-banner">La Bot Bot</div>
+    <header class="hero">
+        <h1>Kawaii Dashboard</h1>
+        <p class="subtitle">Super cute status page for LaBotBot</p>
+        <div class="banner"> <!-- Add your cute pattern image here --> </div>
+    </header>
+
+    <nav class="tabs">
+        <button data-tab="products" class="active">Products</button>
+        <button data-tab="logs">Logs</button>
+    </nav>
+
+    <main>
+        <section id="products" class="tab-content active">
+            <h2>Priority Links</h2>
+            <ul id="priority-list"></ul>
+            <h2>Products</h2>
+            <table id="products-table">
+                <thead>
+                    <tr><th>Name</th><th>Price</th><th>In Stock</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+        <section id="logs" class="tab-content">
+            <h2>Latest Logs</h2>
+            <pre id="log-text"></pre>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 LaBotBot</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/cute_site/script.js
+++ b/cute_site/script.js
@@ -1,0 +1,71 @@
+function switchTab(tab) {
+    document.querySelectorAll('.tab-content').forEach(el => {
+        el.classList.toggle('active', el.id === tab);
+    });
+    document.querySelectorAll('.tabs button').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.tab === tab);
+    });
+}
+
+document.querySelectorAll('.tabs button').forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+});
+
+const API_BASE = location.protocol === 'file:' ? 'http://localhost:8000' : '';
+
+async function fetchPriority() {
+    try {
+        const res = await fetch(`${API_BASE}/api/priority`);
+        const data = await res.json();
+        const list = document.getElementById('priority-list');
+        list.innerHTML = '';
+        data.forEach(link => {
+            const li = document.createElement('li');
+            li.textContent = link;
+            list.appendChild(li);
+        });
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+async function fetchProducts() {
+    try {
+        const res = await fetch(`${API_BASE}/api/products`);
+        const data = await res.json();
+        const tbody = document.querySelector('#products-table tbody');
+        tbody.innerHTML = '';
+        data.forEach(p => {
+            const tr = document.createElement('tr');
+            const name = p.name || '';
+            const url = p.url || '#';
+            const price = p.price !== undefined ? `$${p.price}` : '';
+            const inStock = p.in_stock === '1' ? 'Yes' : 'No';
+            tr.innerHTML = `<td><a href="${url}" target="_blank">${name}</a></td><td>${price}</td><td>${inStock}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+async function fetchLogs() {
+    try {
+        const res = await fetch(`${API_BASE}/api/logs`);
+        const data = await res.json();
+        document.getElementById('log-text').textContent = data.logs || '';
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+function refreshData() {
+    fetchPriority();
+    fetchProducts();
+    fetchLogs();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    refreshData();
+    setInterval(refreshData, 30000);
+});

--- a/cute_site/styles.css
+++ b/cute_site/styles.css
@@ -1,0 +1,126 @@
+:root {
+    --pink: #e48bae;
+    --purple: #9575cd;
+    --lavender: #d1c4e9;
+    --mint: #7cdfff;
+    --text: #333;
+}
+
+.page-banner {
+    background: #f5e9ff;
+    font-family: 'Comic Sans MS', 'Trebuchet MS', cursive;
+    color: var(--purple);
+    text-align: center;
+    padding: 1rem;
+    font-size: 2rem;
+}
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+    background: var(--lavender);
+    color: var(--text);
+}
+
+.hero {
+    background: linear-gradient(135deg, var(--pink), var(--purple));
+    color: white;
+    padding: 2rem 1rem;
+    text-align: center;
+    position: relative;
+}
+
+.banner {
+    margin-top: 1rem;
+    height: 150px;
+    background: url('banner-placeholder.png') center/cover no-repeat;
+    border-radius: 12px;
+}
+
+.subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+}
+
+.tabs {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin: 1rem 0;
+}
+
+.tabs button {
+    background: var(--pink);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.2s;
+}
+
+.tabs button.active,
+.tabs button:hover {
+    background: var(--purple);
+    transform: translateY(-2px);
+}
+
+main {
+    max-width: 900px;
+    margin: auto;
+    background: white;
+    padding: 1rem 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+#products-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#products-table th,
+#products-table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--lavender);
+    text-align: left;
+}
+
+#priority-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+#priority-list li {
+    background: var(--mint);
+    color: var(--text);
+    padding: 0.5rem 1rem;
+    margin-bottom: 0.5rem;
+    border-radius: 20px;
+}
+
+#log-text {
+    background: #222;
+    color: #eee;
+    padding: 1rem;
+    border-radius: 8px;
+    max-height: 300px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+footer {
+    text-align: center;
+    margin-top: 2rem;
+    padding: 1rem;
+    color: var(--text);
+}

--- a/dashboard.py
+++ b/dashboard.py
@@ -60,6 +60,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def _send_json(self, data):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(json.dumps(data, indent=2).encode())
 


### PR DESCRIPTION
## Summary
- add a new `cute_site` with HTML, CSS and JS
- theme uses pastel BTS-inspired colors with rounded buttons
- JS fetches data from the existing dashboard API
- document the new interface in the README
- make product names clickable and add a banner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ef23b19e483269d7a17416063b5a7